### PR TITLE
Shebang should come before encoding

### DIFF
--- a/binGraph.py
+++ b/binGraph.py
@@ -1,5 +1,5 @@
-#encoding: utf-8
 #!/usr/bin/env python
+#encoding: utf-8
 
 import sys
 import pkgutil


### PR DESCRIPTION
otherwise it's not possible to launch this directly